### PR TITLE
tcp_conn_validator: Initial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
 # puppet-healthcheck
+
+## Types
+
+### tcp_conn_validator
+
+`tcp_conn_validator` is used to verify that a service is listening on a given port.
+It could be used to test either a remote or a local service. It support both IPv4 and
+IPv6 connection strings. It also works with hostname.
+
+```puppet
+tcp_conn_validator { 'foo-machine ssh service' :
+  host => '192.168.0.42',
+  port   => 22,
+}
+```
+
+The namevar of this resource can also be the connection string. It comes handy when
+one already have an array of ip:port or hostname:port string to test.
+
+```puppet
+mongodb_cluster_nodes = ['192.168.0.2:27017', 'node02.foo.bar.com:27017']
+tcp_conn_validator { $mongodb_cluster_nodes : }
+```
+
+####`host`
+
+IP address or server DNS name on which the service is supposed to be bound to. Required if the namevar is not a connection string.
+
+####`port`
+
+Port on which the service is supposed to listen. Required if the namevar is not a connection string.
+
+####`try_sleep`
+
+The time to sleep in seconds between ‘tries’. Default: 1
+
+####`timeout`
+
+Number of seconds to wait before timing out. Default: 60

--- a/lib/puppet/provider/tcp_conn_validator/tcp_port.rb
+++ b/lib/puppet/provider/tcp_conn_validator/tcp_port.rb
@@ -1,0 +1,48 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
+require 'puppet_x/puppet-community/tcp_validator'
+
+# This file contains a provider for the resource type `tcp_conn_validator`,
+# which validates the TCP connection.
+
+Puppet::Type.type(:tcp_conn_validator).provide(:tcp_port) do
+  desc "A provider for the resource type `tcp_conn_validator`,
+        which validates the tcp connection."
+
+  def exists?
+    start_time = Time.now
+    timeout = resource[:timeout]
+    try_sleep = resource[:try_sleep]
+
+    success = validator.attempt_connection
+
+    while success == false && ((Time.now - start_time) < timeout)
+      Puppet.debug("Failed to connect to the host; sleeping #{try_sleep} seconds before retry")
+      sleep try_sleep
+      success = validator.attempt_connection
+    end
+
+    if success
+      Puppet.debug("Connected to the host in #{Time.now - start_time} seconds.")
+    else
+      Puppet.notice("Failed to connect to the host within timeout window of #{timeout} seconds; giving up.")
+    end
+
+    success
+  end
+
+  def create
+    # If `#create` is called, that means that `#exists?` returned false, which
+    # means that the connection could not be established... so we need to
+    # cause a failure here.
+    raise Puppet::Error, "Unable to connect to the  host. (#{@validator.tcp_server}:#{@validator.tcp_port})"
+  end
+
+  private
+
+  # @api private
+  def validator
+    @validator ||= PuppetX::PuppetCommunity::TcpValidator.new(resource[:name], resource[:host], resource[:port])
+  end
+
+end
+

--- a/lib/puppet/type/tcp_conn_validator.rb
+++ b/lib/puppet/type/tcp_conn_validator.rb
@@ -1,0 +1,56 @@
+Puppet::Type.newtype(:tcp_conn_validator) do
+
+  @doc = "Verify that a TCP connection can be successfully established between a node
+          and the expected host.  Its primary use is as a precondition to
+          prevent configuration changes from being applied if the host cannot be
+          reached, but it could potentially be used for other purposes such as monitoring."
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name, :namevar => true) do
+    desc 'An arbitrary name used as the identity of the resource.'
+  end
+
+  newparam(:host) do
+    desc 'An array containing DNS names or IP addresses of the host where the expected service should be running.'
+    munge do |value|
+      Array(value).first
+    end
+  end
+
+  newparam(:port) do
+    desc 'The port that the server should be listening on.'
+  end
+
+  newparam(:try_sleep) do
+    desc 'The time to sleep in seconds between ‘tries’.'
+    defaultto 1
+
+    validate do |value|
+      # This will raise an error if the string is not convertible to an integer
+      Integer(value)
+    end
+
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+  newparam(:timeout) do
+    desc 'The max number of seconds that the validator should wait before giving up and deciding that the service is not running; defaults to 60 seconds.'
+    defaultto 60
+
+    validate do |value|
+      # This will raise an error if the string is not convertible to an integer
+      Integer(value)
+    end
+
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+end

--- a/lib/puppet_x/puppet-community/tcp_validator.rb
+++ b/lib/puppet_x/puppet-community/tcp_validator.rb
@@ -1,0 +1,47 @@
+require 'socket'
+require 'timeout'
+require 'ipaddr'
+
+module PuppetX
+  module PuppetCommunity
+    class TcpValidator
+      attr_reader :tcp_server
+      attr_reader :tcp_port
+
+      def initialize(tcp_resource_name, tcp_server, tcp_port)
+        begin
+          # NOTE (spredzy) : By relying on the uri module
+          # we rely on its well tested interface to parse
+          # both IPv4 and IPv6 based URL with a port specified.
+          # Unfortunately URI needs a scheme, hence the http
+          # string here to make the string URI compliant.
+          uri = URI("http://#{tcp_resource_name}")
+          @tcp_server = IPAddr.new(Socket.getaddrinfo(uri.host, nil)[0][3]).to_s
+          @tcp_port = uri.port
+        rescue
+          @tcp_server = IPAddr.new(Socket.getaddrinfo(tcp_server, nil)[0][3]).to_s
+          @tcp_port   = tcp_port
+        end
+      end
+
+      # Utility method; attempts to make a tcp connection to the specified server.
+      # This is abstracted out into a method so that it can be called multiple times
+      # for retry attempts.
+      #
+      # @return true if the connection is successful, false otherwise.
+      def attempt_connection
+        Timeout::timeout(Puppet[:configtimeout]) do
+          begin
+            TCPSocket.new(@tcp_server, @tcp_port).close
+            true
+          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH => e
+            Puppet.debug "Unable to connect to tcp host (#{@tcp_server}:#{@tcp_port}): #{e.message}"
+            false
+          end
+        end
+      rescue Timeout::Error
+        false
+      end
+    end
+  end
+end


### PR DESCRIPTION
Initial commit of the new provider tcp_conn_validator that allows
one to check if a service is actually listening on a given pair ip:host.
It supports both IPv4 and IPv6 address.

It either takes a string connection in the namevar or received the
informations through the `server` and `port` parameters.

Case 1:
``` puppet
tcp_conn_validator { '127.0.0.1:22' : }
```
Case 2:
```puppet
 tcp_conn_validator { 'local ssh' :
   server => '127.0.0.1',
   port   => 22,
 }
```