### PR TITLE
http_conn_validator: Initial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,50 @@ The time to sleep in seconds between ‘tries’. Default: 1
 ####`timeout`
 
 Number of seconds to wait before timing out. Default: 60
+
+### http_conn_validator
+
+`http_conn_validator` is used to verify that an http server is answering on a given port.
+It could be used to test either a remote or a local service. It support both IPv4 and
+IPv6 connection strings. It also works with hostname.
+
+```puppet
+http_conn_validator { 'foo-machine home' :
+  home    => '127.0.0.1',
+  port    => 80,
+  use_ssl => true,
+}
+```
+
+The namevar of this resource can also be the connection string. It comes handy when
+one already have an array of URLs string to test.
+
+```puppet
+appli_cluster_nodes = ['https://server1.com/test-url', 'https://server2.com/test-url']
+http_conn_validator { $appli_cluster_nodes : }
+```
+
+####`host`
+
+IP address or server DNS name on which the service is supposed to be bound to. Required if the namevar is not a connection string.
+
+####`port`
+
+Port on which the service is supposed to listen. Required if the namevar is not a connection string.
+
+####`use_ssl`
+
+Whether the connection will be attempted using https. Default: false
+
+####`test_url`
+
+URL to use for testing if the HTTP server is up. Default: /
+
+####`try_sleep`
+
+The time to sleep in seconds between ‘tries’. Default: 1
+
+####`timeout`
+
+Number of seconds to wait before timing out. Default: 60
+

--- a/lib/puppet/provider/http_conn_validator/http_conn_validator.rb
+++ b/lib/puppet/provider/http_conn_validator/http_conn_validator.rb
@@ -1,0 +1,65 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
+require 'puppet_x/puppet-community/http_validator'
+
+# This file contains a provider for the resource type `http_conn_validator`,
+# which validates an HTTP connection by attempting an http(s) connection.
+
+Puppet::Type.type(:http_conn_validator).provide(:http_conn_validator) do
+  desc "A provider for the resource type `http_conn_validator`,
+        which validates an HTTP connection by attempting an http(s)
+        connection to the server."
+
+  # Test to see if the resource exists, returns true if it does, false if it
+  # does not.
+  #
+  # Here we simply monopolize the resource API, to execute a test to see if the
+  # database is connectable. When we return a state of `false` it triggers the
+  # create method where we can return an error message.
+  #
+  # @return [bool] did the test succeed?
+  def exists?
+    start_time = Time.now
+    timeout = resource[:timeout]
+    try_sleep = resource[:try_sleep]
+
+    success = validator.attempt_connection
+
+    while success == false && ((Time.now - start_time) < timeout)
+      # It can take several seconds for an HTTP  service to start up;
+      # especially on the first install.  Therefore, our first connection attempt
+      # may fail.  Here we have somewhat arbitrarily chosen to retry every 2
+      # seconds until the configurable timeout has expired.
+      Puppet.notice("Failed to make an HTTP connection; sleeping #{try_sleep} seconds before retry")
+      sleep try_sleep
+      success = validator.attempt_connection
+    end
+
+    if success
+      Puppet.debug("Connected to the host in #{Time.now - start_time} seconds.")
+    else
+      Puppet.notice("Failed to make an HTTP connection within timeout window of #{timeout} seconds; giving up.")
+    end
+
+    success
+  end
+
+  # This method is called when the exists? method returns false.
+  #
+  # @return [void]
+  def create
+    # If `#create` is called, that means that `#exists?` returned false, which
+    # means that the connection could not be established... so we need to
+    # cause a failure here.
+    raise Puppet::Error, "Unable to connect to the HTTP server! (#{@validator.http_server}:#{@validator.http_port})"
+  end
+
+  # Returns the existing validator, if one exists otherwise creates a new object
+  # from the class.
+  #
+  # @api private
+  def validator
+    @validator ||= PuppetX::PuppetCommunity::HttpValidator.new(resource[:name], resource[:host], resource[:port], resource[:use_ssl], resource[:test_url])
+  end
+
+end
+

--- a/lib/puppet/type/http_conn_validator.rb
+++ b/lib/puppet/type/http_conn_validator.rb
@@ -1,0 +1,67 @@
+Puppet::Type.newtype(:http_conn_validator) do
+
+  @doc = "Verify that a connection can be successfully established between a node
+          and an HTTP server.  Its primary use is as a precondition to
+          prevent configuration changes from being applied if the HTTP
+          server cannot be reached, but it could potentially be used for other
+          purposes such as monitoring."
+
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name, :namevar => true) do
+    desc 'An arbitrary name used as the identity of the resource.'
+  end
+
+  newparam(:host) do
+    desc 'An array containing DNS names or IP addresses of the host where the expected service should be running.'
+    munge do |value|
+      Array(value).first
+    end
+  end
+
+  newparam(:port) do
+    desc 'The port that the server should be listening on.'
+  end
+
+  newparam(:use_ssl) do
+    desc 'Whether the connection will be attemped using https'
+    defaultto false
+  end
+
+  newparam(:test_url) do
+    desc 'URL to use for testing if the HTTP server is up'
+    defaultto '/'
+  end
+
+  newparam(:try_sleep) do
+    desc 'The time to sleep in seconds between ‘tries’.'
+    defaultto 1
+
+    validate do |value|
+      # This will raise an error if the string is not convertible to an integer
+      Integer(value)
+    end
+
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+  newparam(:timeout) do
+    desc 'The max number of seconds that the validator should wait before giving up and deciding that the service is not running; defaults to 60 seconds.'
+    defaultto 60
+
+    validate do |value|
+      # This will raise an error if the string is not convertible to an integer
+      Integer(value)
+    end
+
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+end

--- a/lib/puppet_x/puppet-community/http_validator.rb
+++ b/lib/puppet_x/puppet-community/http_validator.rb
@@ -1,0 +1,49 @@
+require 'puppet/network/http_pool'
+
+module PuppetX
+  module PuppetCommunity
+    class HttpValidator
+      attr_reader :http_server
+      attr_reader :http_port
+      attr_reader :use_ssl
+      attr_reader :test_path
+      attr_reader :test_headers
+
+      def initialize(http_resource_name, http_server, http_port, use_ssl, test_path)
+        if http_resource_name =~ /\A#{URI::regexp}\z/
+          uri = URI(http_resource_name)
+          @http_server = uri.host
+          @http_port   = uri.port
+          @use_ssl     = uri.scheme.eql?('https') ? true : false
+          @test_path   = uri.request_uri
+        else
+          @http_server = http_server
+          @http_port   = http_port
+          @use_ssl     = use_ssl
+          @test_path   = test_path
+        end
+        @test_headers = { "Accept" => "application/json" }
+      end
+
+      # Utility method; attempts to make an http/https connection to a server.
+      # This is abstracted out into a method so that it can be called multiple times
+      # for retry attempts.
+      #
+      # @return true if the connection is successful, false otherwise.
+      def attempt_connection
+        conn = Puppet::Network::HttpPool.http_instance(http_server, http_port, use_ssl)
+
+        response = conn.get(test_path, test_headers)
+        unless response.kind_of?(Net::HTTPSuccess)
+          Puppet.notice "Unable to connect to the server (http#{use_ssl ? "s" : ""}://#{http_server}:#{http_port}): [#{response.code}] #{response.msg}"
+          return false
+        end
+        return true
+      rescue Exception => e
+        Puppet.notice "Unable to connect to the server (http#{use_ssl ? "s" : ""}://#{http_server}:#{http_port}): #{e.message}"
+        return false
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Initial commit of the new provider http_conn_validator that allows
one to check if a web service is actually listening on a given ip,
port and specific URL. The https protocol can be used if specified.
It supports both IPv4 and IPv6 address.

It either takes a string connection in the namevar or received the
informations through the `server`, `port`, `use_ssl` and `test_url`
parameters.

Case 1:
```puppet
   http_conn_validator { 'https://127.0.0.1:8080/test_url' : }
```
Case 2:
```puppet
   http_conn_validator { 'local elasticsearch' :
     server => '127.0.0.1',
     port   => 9200,
   }
```