### PR TITLE
Remove UTF-8 characters from strings

### DIFF
--- a/lib/puppet/type/tcp_conn_validator.rb
+++ b/lib/puppet/type/tcp_conn_validator.rb
@@ -26,7 +26,7 @@ Puppet::Type.newtype(:tcp_conn_validator) do
   end
 
   newparam(:try_sleep) do
-    desc 'The time to sleep in seconds between ‘tries’.'
+    desc "The time to sleep in seconds between 'tries'."
     defaultto 1
 
     validate do |value|


### PR DESCRIPTION
The tcp_conn_validator `try_sleep` parameter has unnecessary UTF-8 quote
characters which cause errors on some Puppet installs.  This changes
them to US-ASCII single quote characters.